### PR TITLE
Backports to php5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,18 +15,18 @@
         }
     ],
     "require": {
-        "php": "^7.1.3 || ^8.0",
+        "php": "^5.6",
         "apix/log": "^1.2",
-        "evenement/evenement": "^3.0.1",
+        "evenement/evenement": "^2.1",
         "psr/log": "^1.0",
-        "symfony/filesystem": "^3.3|^4.0|^5.0",
-        "symfony/process": "^3.3|^4.0|^5.0",
+        "symfony/filesystem": "^3.4",
+        "symfony/process": "^3.4",
         "wrench/wrench": "^2.0"
     },
     "require-dev":{
         "bamarni/composer-bin-plugin": "^1.4.1",
-        "phpunit/phpunit": "^7.5.20 || ^8.5.13 || ^9.5.0",
-        "symfony/var-dumper": "^3.3|^4.0|^5.0"
+        "phpunit/phpunit": "^5.4",
+        "symfony/var-dumper": "^3.4"
     },
     "autoload":{
         "psr-4" : {

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -82,7 +82,7 @@ class Browser
     /**
      * @return Connection
      */
-    public function getConnection(): Connection
+    public function getConnection()
     {
         return $this->connection;
     }
@@ -93,7 +93,7 @@ class Browser
      *
      * @param string|null $script
      */
-    public function setPagePreScript(string $script = null)
+    public function setPagePreScript($script = null)
     {
         $this->pagePreScript = $script;
     }
@@ -129,7 +129,7 @@ class Browser
      * @throws OperationTimedOut
      * @return Page
      */
-    public function createPage(): Page
+    public function createPage()
     {
 
         // page url

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -226,7 +226,7 @@ class BrowserProcess implements LoggerAwareInterface
                     // wait for process to close
                     $generator = function (Process $process) {
                         while ($process->isRunning()) {
-                            (yield 2 * 1000); // wait for 2ms
+                            (yield 0 => 2 * 1000); // wait for 2ms
                         }
                     };
                     $timeout = 8 * 1000 * 1000; // 8 seconds
@@ -374,8 +374,8 @@ class BrowserProcess implements LoggerAwareInterface
         // log
         $this->logger->debug('process: waiting for ' . $timeout / 1000000 . ' seconds for startup');
 
-        try {
-            $generator = function (Process $process) {
+        #try {
+        #    $generator = function (Process $process) {
                 while (true) {
                     if (!$process->isRunning()) {
                         // log
@@ -419,13 +419,14 @@ class BrowserProcess implements LoggerAwareInterface
                     }
 
                     // wait for 10ms
-                    (yield 10 * 1000);
+                    usleep(10 * 1000);
+                    #(yield 10 * 1000);
                 }
-            };
-            return Utils::tryWithTimeout($timeout, $generator($process));
-        } catch (OperationTimedOut $e) {
-            throw new \RuntimeException('Cannot start browser', 0, $e);
-        }
+        #    };
+        #    return Utils::tryWithTimeout($timeout, $generator($process));
+        #} catch (OperationTimedOut $e) {
+        #    throw new \RuntimeException('Cannot start browser', 0, $e);
+        #}
     }
 
     /**

--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -81,7 +81,7 @@ class BrowserProcess implements LoggerAwareInterface
     {
 
         // set or create logger
-        $this->setLogger($logger ?? new NullLogger());
+        $this->setLogger(isset($logger) ? $logger : new NullLogger());
     }
 
     /**
@@ -133,14 +133,14 @@ class BrowserProcess implements LoggerAwareInterface
         $process->start();
 
         // wait for start and retrieve ws uri
-        $startupTimeout = $options['startupTimeout'] ?? 30;
+        $startupTimeout = isset($options['startupTimeout']) ? $options['startupTimeout'] : 30;
         $this->wsUri = $this->waitForStartup($process, $startupTimeout * 1000 * 1000);
 
         // log
         $this->logger->debug('process: connecting using ' . $this->wsUri);
 
         // connect to browser
-        $connection = new Connection($this->wsUri, $this->logger, $options['sendSyncDefaultTimeout'] ?? 5000);
+        $connection = new Connection($this->wsUri, $this->logger, isset($options['sendSyncDefaultTimeout']) ? $options['sendSyncDefaultTimeout'] : 5000);
         $connection->connect();
 
         // connection delay
@@ -226,7 +226,7 @@ class BrowserProcess implements LoggerAwareInterface
                     // wait for process to close
                     $generator = function (Process $process) {
                         while ($process->isRunning()) {
-                            yield 2 * 1000; // wait for 2ms
+                            (yield 2 * 1000); // wait for 2ms
                         }
                     };
                     $timeout = 8 * 1000 * 1000; // 8 seconds
@@ -369,7 +369,7 @@ class BrowserProcess implements LoggerAwareInterface
      * @param int $timeout
      * @return mixed
      */
-    private function waitForStartup(Process $process, int $timeout)
+    private function waitForStartup(Process $process, $timeout)
     {
         // log
         $this->logger->debug('process: waiting for ' . $timeout / 1000000 . ' seconds for startup');
@@ -419,7 +419,7 @@ class BrowserProcess implements LoggerAwareInterface
                     }
 
                     // wait for 10ms
-                    yield 10 * 1000;
+                    (yield 10 * 1000);
                 }
             };
             return Utils::tryWithTimeout($timeout, $generator($process));

--- a/src/BrowserFactory.php
+++ b/src/BrowserFactory.php
@@ -23,10 +23,10 @@ class BrowserFactory
 {
     protected $chromeBinary;
 
-    public function __construct(string $chromeBinary = null)
+    public function __construct($chromeBinary = null)
     {
         // auto guess chrome binary
-        $this->chromeBinary = $chromeBinary ?? ($_SERVER['CHROME_PATH'] ?? 'chrome');
+        $this->chromeBinary = isset($chromeBinary) ? $chromeBinary : (isset($_SERVER['CHROME_PATH']) ? $_SERVER['CHROME_PATH'] : 'chrome');
     }
 
     /**
@@ -49,7 +49,7 @@ class BrowserFactory
      *
      * @return ProcessAwareBrowser a Browser instance to interact with the new chrome process
      */
-    public function createBrowser(array $options = []): ProcessAwareBrowser
+    public function createBrowser(array $options = [])
     {
 
         // create logger from options
@@ -123,7 +123,7 @@ class BrowserFactory
      * @return Browser
      * @throws BrowserConnectionFailed
      */
-    public static function connectToBrowser(string $uri, array $options = []): Browser
+    public static function connectToBrowser($uri, array $options = [])
     {
         $logger = self::createLogger($options);
 
@@ -132,7 +132,7 @@ class BrowserFactory
         }
 
         // connect to browser
-        $connection = new Connection($uri, $logger, $options['sendSyncDefaultTimeout'] ?? 5000);
+        $connection = new Connection($uri, $logger, isset($options['sendSyncDefaultTimeout']) ? $options['sendSyncDefaultTimeout'] : 5000);
 
         // try to connect
         try {
@@ -162,7 +162,7 @@ class BrowserFactory
     private static function createLogger($options)
     {
         // prepare logger
-        $logger = $options['debugLogger'] ?? null;
+        $logger = isset($options['debugLogger']) ? $options['debugLogger'] : null;
 
         // create logger from string name or resource
         if (is_string($logger) || is_resource($logger)) {

--- a/src/Communication/Connection.php
+++ b/src/Communication/Connection.php
@@ -29,9 +29,9 @@ class Connection extends EventEmitter implements LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
-    public const EVENT_TARGET_CREATED = 'method:Target.targetCreated';
-    public const EVENT_TARGET_INFO_CHANGED = 'method:Target.targetInfoChanged';
-    public const EVENT_TARGET_DESTROYED = 'method:Target.targetDestroyed';
+    const EVENT_TARGET_CREATED = 'method:Target.targetCreated';
+    const EVENT_TARGET_INFO_CHANGED = 'method:Target.targetInfoChanged';
+    const EVENT_TARGET_DESTROYED = 'method:Target.targetDestroyed';
 
     /**
      * When strict mode is enabled communication error will result in exceptions
@@ -85,13 +85,13 @@ class Connection extends EventEmitter implements LoggerAwareInterface
      * @param SocketInterface|string $socketClient
      * @param int|null $sendSyncDefaultTimeout
      */
-    public function __construct($socketClient, LoggerInterface $logger = null, int $sendSyncDefaultTimeout = null)
+    public function __construct($socketClient, LoggerInterface $logger = null, $sendSyncDefaultTimeout = null)
     {
         // set or create logger
-        $this->setLogger($logger ?? new NullLogger());
+        $this->setLogger(isset($logger) ? $logger : new NullLogger());
 
         // set timeout
-        $this->sendSyncDefaultTimeout = $sendSyncDefaultTimeout ?? 5000;
+        $this->sendSyncDefaultTimeout = isset($sendSyncDefaultTimeout) ? $sendSyncDefaultTimeout : 5000;
 
         // create socket client
         if (is_string($socketClient)) {
@@ -108,7 +108,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
     /**
      * @return LoggerInterface
      */
-    public function getLogger(): LoggerInterface
+    public function getLogger()
     {
         return $this->logger;
     }
@@ -117,7 +117,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
      * Set the delay to apply everytime before data are sent
      * @param int $delay
      */
-    public function setConnectionDelay(int $delay)
+    public function setConnectionDelay($delay)
     {
         $this->delay = $delay;
     }
@@ -126,7 +126,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
      * Gets the default timeout used when sending a message synchronously
      * @return int
      */
-    public function getSendSyncDefaultTimeout(): int
+    public function getSendSyncDefaultTimeout()
     {
         return $this->sendSyncDefaultTimeout;
     }
@@ -134,7 +134,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
     /**
      * @return bool
      */
-    public function isStrict(): bool
+    public function isStrict()
     {
         return $this->strict;
     }
@@ -142,7 +142,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
     /**
      * @param bool $strict
      */
-    public function setStrict(bool $strict)
+    public function setStrict($strict)
     {
         $this->strict = $strict;
     }
@@ -197,7 +197,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
      * @throws CommunicationException
      * @return ResponseReader
      */
-    public function sendMessage(Message $message): ResponseReader
+    public function sendMessage(Message $message)
     {
 
         // if delay enabled wait before sending message
@@ -228,10 +228,10 @@ class Connection extends EventEmitter implements LoggerAwareInterface
      * @throws OperationTimedOut
      * @return Response
      */
-    public function sendMessageSync(Message $message, int $timeout = null): Response
+    public function sendMessageSync(Message $message, $timeout = null)
     {
         $responseReader = $this->sendMessage($message);
-        $response = $responseReader->waitForResponse($timeout ?? $this->sendSyncDefaultTimeout);
+        $response = $responseReader->waitForResponse(isset($timeout) ? $timeout : $this->sendSyncDefaultTimeout);
 
         return $response;
     }
@@ -241,7 +241,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
      * @param string $targetId
      * @return Session
      */
-    public function createSession($targetId): Session
+    public function createSession($targetId)
     {
         $response = $this->sendMessageSync(
             new Message('Target.attachToTarget', ['targetId' => $targetId])
@@ -310,7 +310,7 @@ class Connection extends EventEmitter implements LoggerAwareInterface
      * @throws InvalidResponse
      * @internal
      */
-    private function dispatchMessage(string $message, Session $session = null)
+    private function dispatchMessage($message, Session $session = null)
     {
 
         // responses come as json string

--- a/src/Communication/Message.php
+++ b/src/Communication/Message.php
@@ -48,7 +48,7 @@ class Message
      * @param string $method
      * @param array $params
      */
-    public function __construct(string $method, array $params = [])
+    public function __construct($method, array $params = [])
     {
         $this->id = ++self::$messageId;
         $this->method = $method;
@@ -58,7 +58,7 @@ class Message
     /**
      * @return int
      */
-    public function getId(): int
+    public function getId()
     {
         return $this->id;
     }
@@ -66,7 +66,7 @@ class Message
     /**
      * @return string
      */
-    public function getMethod(): string
+    public function getMethod()
     {
         return $this->method;
     }
@@ -74,7 +74,7 @@ class Message
     /**
      * @return array
      */
-    public function getParams(): array
+    public function getParams()
     {
         return $this->params;
     }
@@ -82,7 +82,7 @@ class Message
     /**
      * @inheritdoc
      */
-    public function __toString(): string
+    public function __toString()
     {
         return json_encode([
             'id'        => $this->getId(),

--- a/src/Communication/Response.php
+++ b/src/Communication/Response.php
@@ -39,7 +39,7 @@ class Response implements \ArrayAccess
      * Get the error message if set.
      * @return string|null
      */
-    public function getErrorMessage(bool $extended = true)
+    public function getErrorMessage($extended = true)
     {
         $message = [];
 
@@ -64,7 +64,7 @@ class Response implements \ArrayAccess
      */
     public function getErrorCode()
     {
-        return $this->data['error']['code'] ?? null;
+        return isset($this->data['error']['code']) ? $this->data['error']['code'] : null;
     }
 
     /**
@@ -73,13 +73,13 @@ class Response implements \ArrayAccess
      */
     public function getResultData($name)
     {
-        return $this->data['result'][$name] ?? null;
+        return isset($this->data['result'][$name]) ? $this->data['result'][$name] : null;
     }
 
     /**
      * @return Message
      */
-    public function getMessage(): Message
+    public function getMessage()
     {
         return $this->message;
     }
@@ -88,7 +88,7 @@ class Response implements \ArrayAccess
      * The data returned by chrome dev tools
      * @return array
      */
-    public function getData(): array
+    public function getData()
     {
         return $this->data;
     }

--- a/src/Communication/ResponseReader.php
+++ b/src/Communication/ResponseReader.php
@@ -125,12 +125,15 @@ class ResponseReader
 
             // if found return it
             if ($hasResponse) {
-                return $this->getResponse();
+                break;
+                #return $this->getResponse();
             }
 
             // wait before next check
-            yield $tryDelay;
+            yield 0 => $tryDelay;
         }
+
+        yield 1 => $this->getResponse();
     }
 
     /**

--- a/src/Communication/ResponseReader.php
+++ b/src/Communication/ResponseReader.php
@@ -56,7 +56,7 @@ class ResponseReader
      * the message to get a response for
      * @return Message
      */
-    public function getMessage(): Message
+    public function getMessage()
     {
         return $this->message;
     }
@@ -65,7 +65,7 @@ class ResponseReader
      * The connection to check messages for
      * @return Connection
      */
-    public function getConnection(): Connection
+    public function getConnection()
     {
         return $this->connection;
     }
@@ -79,7 +79,7 @@ class ResponseReader
      * @return Response
      * @throws NoResponseAvailable
      */
-    public function getResponse(): Response
+    public function getResponse()
     {
         if (!$this->response) {
             throw new NoResponseAvailable('Response is not available. Try to use the method waitForResponse instead.');
@@ -96,14 +96,14 @@ class ResponseReader
      * @throws NoResponseAvailable
      * @throws OperationTimedOut
      */
-    public function waitForResponse(int $timeout = null): Response
+    public function waitForResponse($timeout = null)
     {
         if ($this->hasResponse()) {
             return $this->getResponse();
         }
 
         // default 2000ms
-        $timeout = $timeout ?? 2000;
+        $timeout = isset($timeout) ? $timeout : 2000;
 
         return Utils::tryWithTimeout($timeout * 1000, $this->waitForResponseGenerator());
     }

--- a/src/Communication/Session.php
+++ b/src/Communication/Session.php
@@ -44,7 +44,7 @@ class Session extends EventEmitter
      * @param string $sessionId
      * @param Connection $connection
      */
-    public function __construct(string $targetId, string $sessionId, Connection $connection)
+    public function __construct($targetId, $sessionId, Connection $connection)
     {
         $this->sessionId  = $sessionId;
         $this->targetId   = $targetId;
@@ -56,7 +56,7 @@ class Session extends EventEmitter
      * @return SessionResponseReader
      * @throws CommunicationException
      */
-    public function sendMessage(Message $message): SessionResponseReader
+    public function sendMessage(Message $message)
     {
         if ($this->destroyed) {
             throw new TargetDestroyed('The session was destroyed.');
@@ -77,11 +77,11 @@ class Session extends EventEmitter
      * @throws NoResponseAvailable
      * @throws CommunicationException
      */
-    public function sendMessageSync(Message $message, int $timeout = null): Response
+    public function sendMessageSync(Message $message, $timeout = null)
     {
         $responseReader = $this->sendMessage($message);
 
-        $response = $responseReader->waitForResponse($timeout ?? $this->getConnection()->getSendSyncDefaultTimeout());
+        $response = $responseReader->waitForResponse(isset($timeout) ? $timeout : $this->getConnection()->getSendSyncDefaultTimeout());
 
         if (!$response) {
             throw new NoResponseAvailable('No response was sent in the given timeout');

--- a/src/Communication/SessionResponseReader.php
+++ b/src/Communication/SessionResponseReader.php
@@ -45,7 +45,7 @@ class SessionResponseReader extends ResponseReader
     /**
      * @return ResponseReader
      */
-    public function getTopResponseReader(): ResponseReader
+    public function getTopResponseReader()
     {
         return $this->topResponseReader;
     }

--- a/src/Communication/Socket/MockSocket.php
+++ b/src/Communication/Socket/MockSocket.php
@@ -75,7 +75,7 @@ class MockSocket implements SocketInterface
     /**
      * @inheritdoc
      */
-    public function receiveData(): array
+    public function receiveData()
     {
         $data = $this->receivedData;
         $this->receivedData = [];

--- a/src/Communication/Socket/SocketInterface.php
+++ b/src/Communication/Socket/SocketInterface.php
@@ -28,7 +28,7 @@ interface SocketInterface
      *
      * @return array Payload received since the last call to receive()
      */
-    public function receiveData(): array;
+    public function receiveData();
 
     /**
      * Connect to the server

--- a/src/Communication/Socket/Wrench.php
+++ b/src/Communication/Socket/Wrench.php
@@ -46,7 +46,7 @@ class Wrench implements SocketInterface, LoggerAwareInterface
     {
         $this->client = $client;
 
-        $this->setLogger($logger ?? new NullLogger());
+        $this->setLogger(isset($logger) ? $logger : new NullLogger());
 
         $this->socketId = ++self::$socketIdCounter;
     }
@@ -66,7 +66,7 @@ class Wrench implements SocketInterface, LoggerAwareInterface
     /**
      * @inheritdoc
      */
-    public function receiveData(): array
+    public function receiveData()
     {
         $playloads = $this->client->receive();
 

--- a/src/Communication/Target.php
+++ b/src/Communication/Target.php
@@ -47,7 +47,7 @@ class Target
     /**
      * @return Session
      */
-    public function getSession(): Session
+    public function getSession()
     {
         if ($this->destroyed) {
             throw new TargetDestroyed('The target was destroyed.');
@@ -82,7 +82,7 @@ class Target
     /**
      * @return bool
      */
-    public function isDestroyed(): bool
+    public function isDestroyed()
     {
         return $this->destroyed;
     }
@@ -94,7 +94,7 @@ class Target
      */
     public function getTargetInfo($infoName)
     {
-        return $this->targetInfo[$infoName] ?? null;
+        return isset($this->targetInfo[$infoName]) ? $this->targetInfo[$infoName] : null;
     }
 
     /**

--- a/src/Cookies/Cookie.php
+++ b/src/Cookies/Cookie.php
@@ -67,7 +67,7 @@ class Cookie implements \ArrayAccess
      */
     public function offsetGet($offset)
     {
-        return $this->data[$offset] ?? null;
+        return isset($this->data[$offset]) ? $this->data[$offset] : null;
     }
 
     /**

--- a/src/Cookies/CookiesCollection.php
+++ b/src/Cookies/CookiesCollection.php
@@ -62,7 +62,7 @@ class CookiesCollection implements \IteratorAggregate, \Countable
      * @param int $i
      * @return Cookie
      */
-    public function getAt($i): Cookie
+    public function getAt($i)
     {
         if (!isset($this->cookies[$i])) {
             throw new \RuntimeException(sprintf('No cookie at index %s', $i));
@@ -87,7 +87,7 @@ class CookiesCollection implements \IteratorAggregate, \Countable
      * @param string $value
      * @return CookiesCollection
      */
-    public function filterBy(string $param, string $value)
+    public function filterBy($param, $value)
     {
         return new CookiesCollection(array_filter($this->cookies, function (Cookie $cookie) use ($param, $value) {
             return $cookie[$param] == $value;
@@ -112,7 +112,7 @@ class CookiesCollection implements \IteratorAggregate, \Countable
      * @param string $value
      * @return Cookie|null
      */
-    public function findOneBy(string $param, string $value)
+    public function findOneBy($param, $value)
     {
         foreach ($this->cookies as $cookie) {
             if ($cookie[$param] == $value) {

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -13,7 +13,7 @@ namespace HeadlessChromium;
 
 class Frame
 {
-    public const LIFECYCLE_INIT = 'init';
+    const LIFECYCLE_INIT = 'init';
 
     /**
      * @var array
@@ -69,7 +69,7 @@ class Frame
     /**
      * @return int
      */
-    public function getExecutionContextId(): int
+    public function getExecutionContextId()
     {
         return $this->executionContextId;
     }
@@ -77,7 +77,7 @@ class Frame
     /**
      * @param int $executionContextId
      */
-    public function setExecutionContextId(int $executionContextId)
+    public function setExecutionContextId($executionContextId)
     {
         $this->executionContextId = $executionContextId;
     }
@@ -85,7 +85,7 @@ class Frame
     /**
      * @return string
      */
-    public function getFrameId(): string
+    public function getFrameId()
     {
         return $this->frameId;
     }
@@ -93,7 +93,7 @@ class Frame
     /**
      * @return string
      */
-    public function getLatestLoaderId(): string
+    public function getLatestLoaderId()
     {
         return $this->latestLoaderId;
     }
@@ -102,7 +102,7 @@ class Frame
      * Gets the life cycle events of the frame with the time they occurred at.
      * @return array
      */
-    public function getLifeCycle(): array
+    public function getLifeCycle()
     {
         return $this->lifeCycleEvents;
     }

--- a/src/FrameManager.php
+++ b/src/FrameManager.php
@@ -71,7 +71,7 @@ class FrameManager
      * @param string $frameId
      * @return bool
      */
-    public function hasFrame($frameId): bool
+    public function hasFrame($frameId)
     {
         return array_key_exists($frameId, $this->frames);
     }
@@ -81,7 +81,7 @@ class FrameManager
      * @param string $frameId
      * @return Frame
      */
-    public function getFrame($frameId): Frame
+    public function getFrame($frameId)
     {
         if (!isset($this->frames[$frameId])) {
             throw new \RuntimeException(sprintf('No such frame "%s"', $frameId));
@@ -94,7 +94,7 @@ class FrameManager
      * Gets the main frame
      * @return Frame
      */
-    public function getMainFrame(): Frame
+    public function getMainFrame()
     {
         return $this->mainFrame;
     }

--- a/src/Input/Keyboard.php
+++ b/src/Input/Keyboard.php
@@ -41,7 +41,7 @@ class Keyboard
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      */
-    public function typeText(string $text)
+    public function typeText($text)
     {
         $this->page->assertNotClosed();
 
@@ -78,7 +78,7 @@ class Keyboard
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      */
-    public function typeRawKey(string $key)
+    public function typeRawKey($key)
     {
         $this->page->assertNotClosed();
 
@@ -99,7 +99,7 @@ class Keyboard
      *
      * @return $this
      */
-    public function setKeyInterval(int $milliseconds)
+    public function setKeyInterval($milliseconds)
     {
         if ($milliseconds < 0) {
             $milliseconds = 0;

--- a/src/Input/Mouse.php
+++ b/src/Input/Mouse.php
@@ -16,10 +16,10 @@ use HeadlessChromium\Page;
 
 class Mouse
 {
-    public const BUTTON_LEFT = 'left';
-    public const BUTTON_NONE = 'none';
-    public const BUTTON_RIGHT = 'right';
-    public const BUTTON_MIDDLE = 'middle';
+    const BUTTON_LEFT = 'left';
+    const BUTTON_NONE = 'none';
+    const BUTTON_RIGHT = 'right';
+    const BUTTON_MIDDLE = 'middle';
 
     /**
      * @var Page
@@ -47,7 +47,7 @@ class Mouse
      * @throws \HeadlessChromium\Exception\CommunicationException
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      */
-    public function move(int $x, int $y, array $options = null)
+    public function move($x, $y, array $options = null)
     {
         $this->page->assertNotClosed();
 
@@ -60,7 +60,7 @@ class Mouse
         $this->y = $y;
 
         // number of steps to achieve the move
-        $steps = $options['steps'] ?? 1;
+        $steps = isset($options['steps']) ? $options['steps'] : 1;
         if ($steps <= 0) {
             throw new \InvalidArgumentException('options "steps" for mouse move must be a positive integer');
         }
@@ -88,7 +88,7 @@ class Mouse
             'x' => $this->x,
             'y' => $this->y,
             'type' => 'mousePressed',
-            'button' => $options['button'] ?? self::BUTTON_LEFT,
+            'button' => isset($options['button']) ? $options['button'] : self::BUTTON_LEFT,
             'clickCount' => 1
         ]));
 
@@ -106,7 +106,7 @@ class Mouse
             'x' => $this->x,
             'y' => $this->y,
             'type' => 'mouseReleased',
-            'button' => $options['button'] ?? self::BUTTON_LEFT,
+            'button' => isset($options['button']) ? $options['button'] : self::BUTTON_LEFT,
             'clickCount' => 1
         ]));
 

--- a/src/Page.php
+++ b/src/Page.php
@@ -31,9 +31,9 @@ use HeadlessChromium\PageUtils\ResponseWaiter;
 
 class Page
 {
-    public const DOM_CONTENT_LOADED = 'DOMContentLoaded';
-    public const LOAD = 'load';
-    public const NETWORK_IDLE = 'networkIdle';
+    const DOM_CONTENT_LOADED = 'DOMContentLoaded';
+    const LOAD = 'load';
+    const NETWORK_IDLE = 'networkIdle';
 
     /**
      * @var Target
@@ -75,7 +75,7 @@ class Page
      * @throws CommunicationException
      * @throws NoResponseAvailable
      */
-    public function addPreScript(string $script, array $options = [])
+    public function addPreScript($script, array $options = [])
     {
         // defer script execution
         if (isset($options['onLoad']) && $options['onLoad']) {
@@ -115,7 +115,7 @@ class Page
     /**
      * @return FrameManager
      */
-    public function getFrameManager(): FrameManager
+    public function getFrameManager()
     {
         $this->assertNotClosed();
 
@@ -126,7 +126,7 @@ class Page
      * Get the session this page is attached to
      * @return Session
      */
-    public function getSession(): Session
+    public function getSession()
     {
         $this->assertNotClosed();
 
@@ -138,7 +138,7 @@ class Page
      * @param string $username
      * @param string $password
      */
-    public function setBasicAuthHeader(string $username, string $password)
+    public function setBasicAuthHeader($username, $password)
     {
         $header = base64_encode($username . ':' . $password);
         $this->getSession()->sendMessage(new Message(
@@ -155,11 +155,11 @@ class Page
      * @return PageNavigation
      * @throws Exception\CommunicationException
      */
-    public function navigate(string $url, array $options = [])
+    public function navigate($url, array $options = [])
     {
         $this->assertNotClosed();
 
-        return new PageNavigation($this, $url, $options['strict'] ?? false);
+        return new PageNavigation($this, $url, isset($options['strict']) ? $options['strict'] : false);
     }
 
     /**
@@ -176,7 +176,7 @@ class Page
      * @return PageEvaluation
      * @throws Exception\CommunicationException
      */
-    public function evaluate(string $expression)
+    public function evaluate($expression)
     {
         $this->assertNotClosed();
 
@@ -212,7 +212,7 @@ class Page
      * @return PageEvaluation
      * @throws CommunicationException
      */
-    public function callFunction(string $functionDeclaration, array $arguments = []): PageEvaluation
+    public function callFunction($functionDeclaration, array $arguments = [])
     {
         $this->assertNotClosed();
 
@@ -253,7 +253,7 @@ class Page
      * @return PageEvaluation
      * @throws CommunicationException
      */
-    public function addScriptTag(array $options): PageEvaluation
+    public function addScriptTag(array $options)
     {
         if (isset($options['url']) && isset($options['content'])) {
             throw new \InvalidArgumentException('addScript accepts "url" or "content" option, not both');
@@ -326,7 +326,7 @@ class Page
      * @throws CommunicationException\CannotReadResponse
      * @throws CommunicationException\InvalidResponse
      */
-    public function hasLifecycleEvent(string $event): bool
+    public function hasLifecycleEvent($event)
     {
         $this->assertNotClosed();
 
@@ -404,7 +404,7 @@ class Page
      * @param int|null $timeout
      * @return Clip
      */
-    public function getFullPageClip(int $timeout = null): Clip
+    public function getFullPageClip($timeout = null)
     {
         $contentSize = $this->getLayoutMetrics()->await($timeout)->getContentSize();
         return new Clip(0, 0, $contentSize['width'], $contentSize['height']);
@@ -427,7 +427,7 @@ class Page
      * @return PageScreenshot
      * @throws CommunicationException
      */
-    public function screenshot(array $options = []): PageScreenshot
+    public function screenshot(array $options = [])
     {
         $this->assertNotClosed();
 
@@ -525,7 +525,7 @@ class Page
      * @return PagePdf
      * @throws CommunicationException
      */
-    public function pdf(array $options = []): PagePdf
+    public function pdf(array $options = [])
     {
         $this->assertNotClosed();
 
@@ -725,7 +725,7 @@ class Page
      *
      * @return ResponseWaiter
      */
-    public function setViewport(int $width, int $height)
+    public function setViewport($width, $height)
     {
         return $this->setDeviceMetricsOverride([
             'width' => $width,
@@ -894,7 +894,7 @@ class Page
      * @throws Exception\OperationTimedOut
      * @throws NoResponseAvailable
      */
-    public function getCookies(int $timeout = null)
+    public function getCookies($timeout = null)
     {
         return $this->readCookies()->await($timeout)->getCookies();
     }
@@ -912,7 +912,7 @@ class Page
      * @throws Exception\OperationTimedOut
      * @throws NoResponseAvailable
      */
-    public function getAllCookies(int $timeout = null)
+    public function getAllCookies($timeout = null)
     {
         return $this->readAllCookies()->await($timeout)->getCookies();
     }
@@ -965,7 +965,7 @@ class Page
      * @return ResponseWaiter
      * @throws CommunicationException
      */
-    public function setUserAgent(string $userAgent)
+    public function setUserAgent($userAgent)
     {
         $response = $this->getSession()
             ->sendMessage(

--- a/src/Page.php
+++ b/src/Page.php
@@ -372,18 +372,21 @@ class Page
             // make sure that the current loader is the good one
             if ($this->frameManager->getMainFrame()->getLatestLoaderId() !== $loaderId) {
                 if ($this->hasLifecycleEvent($eventName)) {
-                    return true;
+                    break;
+                    #return true;
                 }
 
-                yield $delay;
+                yield 0 => $delay;
 
                 // else if frame has still the previous loader, wait for the new one
             } else {
-                yield $delay;
+                yield 0 => $delay;
             }
 
             $this->getSession()->getConnection()->readData();
         }
+
+        yield 1 => true;
     }
 
     /**

--- a/src/PageUtils/AbstractBinaryInput.php
+++ b/src/PageUtils/AbstractBinaryInput.php
@@ -33,7 +33,7 @@ abstract class AbstractBinaryInput
     /**
      * @return ResponseReader
      */
-    public function getResponseReader(): ResponseReader
+    public function getResponseReader()
     {
         return $this->responseReader;
     }
@@ -42,7 +42,7 @@ abstract class AbstractBinaryInput
      * Get base64 representation of the file
      * @return mixed
      */
-    public function getBase64(int $timeout = null)
+    public function getBase64($timeout = null)
     {
         $response = $this->responseReader->waitForResponse($timeout);
 
@@ -59,7 +59,7 @@ abstract class AbstractBinaryInput
      * @throws FilesystemException
      * @throws ScreenshotFailed
      */
-    public function saveToFile(string $path, int $timeout = 5000)
+    public function saveToFile($path, $timeout = 5000)
     {
         $response = $this->responseReader->waitForResponse($timeout);
 
@@ -102,5 +102,5 @@ abstract class AbstractBinaryInput
      * @internal
      * @return \Exception
      */
-    abstract protected function getException(string $message): \Exception;
+    abstract protected function getException($message);
 }

--- a/src/PageUtils/PageEvaluation.php
+++ b/src/PageUtils/PageEvaluation.php
@@ -69,7 +69,7 @@ class PageEvaluation
      *
      * @param int|null $timeout
      */
-    public function waitForResponse(int $timeout = null)
+    public function waitForResponse($timeout = null)
     {
         $this->response = $this->responseReader->waitForResponse($timeout);
 
@@ -82,7 +82,7 @@ class PageEvaluation
 
         $result = $this->response->getResultData('result');
 
-        $resultSubType = $result['subtype'] ?? null;
+        $resultSubType = isset($result['subtype']) ? $result['subtype'] : null;
 
         if ($resultSubType == 'error') {
             // TODO dump javascript trace
@@ -100,13 +100,13 @@ class PageEvaluation
      * @return mixed
      * @throws EvaluationFailed
      */
-    public function getReturnValue(int $timeout = null)
+    public function getReturnValue($timeout = null)
     {
         if (!$this->response) {
             $this->waitForResponse($timeout);
         }
 
-        return $this->response->getResultData('result')['value'] ?? null;
+        return isset($this->response->getResultData('result')['value']) ? $this->response->getResultData('result')['value'] : null;
     }
 
     /**
@@ -117,12 +117,12 @@ class PageEvaluation
      * @return mixed
      * @throws EvaluationFailed
      */
-    public function getReturnType(int $timeout = null)
+    public function getReturnType($timeout = null)
     {
         if (!$this->response) {
             $this->waitForResponse($timeout);
         }
 
-        return $this->response->getResultData('result')['type'] ?? null;
+        return isset($this->response->getResultData('result')['type']) ? $this->response->getResultData('result')['type'] : null;
     }
 }

--- a/src/PageUtils/PageLayoutMetrics.php
+++ b/src/PageUtils/PageLayoutMetrics.php
@@ -26,7 +26,7 @@ class PageLayoutMetrics extends ResponseWaiter
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      * @throws \HeadlessChromium\Exception\OperationTimedOut
      */
-    public function getMetrics(): array
+    public function getMetrics()
     {
         $response = $this->awaitResponse();
         return $response->getData()['results'];
@@ -39,7 +39,7 @@ class PageLayoutMetrics extends ResponseWaiter
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      * @throws \HeadlessChromium\Exception\OperationTimedOut
      */
-    public function getContentSize(): array
+    public function getContentSize()
     {
         $response = $this->awaitResponse();
         return $response->getResultData('contentSize');
@@ -52,7 +52,7 @@ class PageLayoutMetrics extends ResponseWaiter
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      * @throws \HeadlessChromium\Exception\OperationTimedOut
      */
-    public function getLayoutViewport(): array
+    public function getLayoutViewport()
     {
         $response = $this->awaitResponse();
         return $response->getResultData('layoutViewport');

--- a/src/PageUtils/PageNavigation.php
+++ b/src/PageUtils/PageNavigation.php
@@ -162,7 +162,7 @@ class PageNavigation
 
                     $this->currentLoaderId = $response->getResultData('loaderId');
                 } else {
-                    yield $delay;
+                    yield 0 => $delay;
                 }
             }
 
@@ -170,16 +170,17 @@ class PageNavigation
             if ($this->frame->getLatestLoaderId() === $this->currentLoaderId) {
                 // check that lifecycle event exists
                 if ($this->page->hasLifecycleEvent($eventName)) {
-                    return true;
+                    break;
+                    #return true;
 
                 // or else just wait for the new event to trigger
                 } else {
-                    yield $delay;
+                    yield 0 => $delay;
                 }
 
             // else if frame has still the previous loader, wait for the new one
             } elseif ($this->frame->getLatestLoaderId() == $this->previousLoaderId) {
-                yield $delay;
+                yield 0 => $delay;
 
             // else if a new loader is present that means that a new navigation started
             } else {
@@ -195,5 +196,7 @@ class PageNavigation
 
             $this->page->getSession()->getConnection()->readData();
         }
+
+        yield 1 => true;
     }
 }

--- a/src/PageUtils/PageNavigation.php
+++ b/src/PageUtils/PageNavigation.php
@@ -73,7 +73,7 @@ class PageNavigation
      * @throws Exception\CommunicationException\CannotReadResponse
      * @throws Exception\CommunicationException\InvalidResponse
      */
-    public function __construct(Page $page, string $url, bool $strict = false)
+    public function __construct(Page $page, $url, $strict = false)
     {
 
         // make sure latest loaderId was pulled
@@ -120,7 +120,7 @@ class PageNavigation
      * @throws NavigationExpired
      * @throws ResponseHasError
      */
-    public function waitForNavigation($eventName = Page::LOAD, int $timeout = null)
+    public function waitForNavigation($eventName = Page::LOAD, $timeout = null)
     {
         if (null === $timeout) {
             $timeout = 30000;

--- a/src/PageUtils/PagePdf.php
+++ b/src/PageUtils/PagePdf.php
@@ -19,7 +19,7 @@ class PagePdf extends AbstractBinaryInput
      * @inheritdoc
      * @internal
      */
-    protected function getException(string $message): \Exception
+    protected function getException($message)
     {
         return new PdfFailed(
             sprintf('Cannot make a PDF. Reason : %s', $message)

--- a/src/PageUtils/PageScreenshot.php
+++ b/src/PageUtils/PageScreenshot.php
@@ -19,7 +19,7 @@ class PageScreenshot extends AbstractBinaryInput
      * @inheritdoc
      * @internal
      */
-    protected function getException(string $message): \Exception
+    protected function getException($message)
     {
         return new ScreenshotFailed(
             sprintf('Cannot make a screenshot. Reason : %s', $message)

--- a/src/PageUtils/ResponseWaiter.php
+++ b/src/PageUtils/ResponseWaiter.php
@@ -44,7 +44,7 @@ class ResponseWaiter
      *
      * @return $this
      */
-    public function await(int $time = null)
+    public function await($time = null)
     {
         $this->response = $this->responseReader->waitForResponse($time);
 
@@ -63,7 +63,7 @@ class ResponseWaiter
      * @throws \HeadlessChromium\Exception\NoResponseAvailable
      * @throws \HeadlessChromium\Exception\OperationTimedOut
      */
-    protected function awaitResponse(int $time = null): Response
+    protected function awaitResponse($time = null)
     {
         if (!$this->response) {
             $this->await($time);
@@ -75,7 +75,7 @@ class ResponseWaiter
     /**
      * @return ResponseReader
      */
-    public function getResponseReader(): ResponseReader
+    public function getResponseReader()
     {
         return $this->responseReader;
     }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -52,28 +52,32 @@ class Utils
     {
         $waitUntilMicroSec = microtime(true) * 1000 * 1000 + $timeoutMicroSec;
 
-        foreach ($generator as $v) {
-            // if timeout reached or if time+delay exceed timeout stop the execution
-            if (microtime(true) * 1000 * 1000 + $v >= $waitUntilMicroSec) {
-                if ($onTimeout) {
-                    // if callback was set execute it
-                    return $onTimeout();
-                } else {
-                    if ($timeoutMicroSec > 1000 * 1000) {
-                        $timeoutPhrase = (int)($timeoutMicroSec / (1000 * 1000)) . 'sec';
-                    } elseif ($timeoutMicroSec > 1000) {
-                        $timeoutPhrase = (int)($timeoutMicroSec / 1000) . 'ms';
+        foreach ($generator as $k => $v) {
+            if ($k === 0) {
+                // if timeout reached or if time+delay exceed timeout stop the execution
+                if (microtime(true) * 1000 * 1000 + (is_int($generator) ? $generator : 0) >= $waitUntilMicroSec) {
+                    if ($onTimeout) {
+                        // if callback was set execute it
+                        return $onTimeout();
                     } else {
-                        $timeoutPhrase = (int)($timeoutMicroSec) . 'μs';
+                        if ($timeoutMicroSec > 1000 * 1000) {
+                            $timeoutPhrase = (int)($timeoutMicroSec / (1000 * 1000)) . 'sec';
+                        } elseif ($timeoutMicroSec > 1000) {
+                            $timeoutPhrase = (int)($timeoutMicroSec / 1000) . 'ms';
+                        } else {
+                            $timeoutPhrase = (int)($timeoutMicroSec) . 'μs';
+                        }
+                        throw new OperationTimedOut('Operation timed out (' . $timeoutPhrase . ')');
                     }
-                    throw new OperationTimedOut('Operation timed out (' . $timeoutPhrase . ')');
+                }
+
+                usleep($v);
+            } else {
+                if ($generator instanceof \Generator) {
+                    return $generator->current();
                 }
             }
-
-            usleep($v);
         }
-
-        return $generator->getReturn();
     }
 
     /**

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -48,7 +48,7 @@ class Utils
      * @return mixed
      * @throws OperationTimedOut
      */
-    public static function tryWithTimeout(int $timeoutMicroSec, \Generator $generator, callable $onTimeout = null)
+    public static function tryWithTimeout($timeoutMicroSec, \Generator $generator, callable $onTimeout = null)
     {
         $waitUntilMicroSec = microtime(true) * 1000 * 1000 + $timeoutMicroSec;
 

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class BaseTestCase extends TestCase
 {
-    protected static function sitePath(string $file): string
+    protected static function sitePath($file)
     {
         return 'file://' . realpath(__DIR__ . '/resources/static-web/' . $file);
     }

--- a/tests/BrowsingTest.php
+++ b/tests/BrowsingTest.php
@@ -25,14 +25,14 @@ class BrowsingTest extends BaseTestCase
      */
     public static $browser;
 
-    public static function setUpBeforeClass(): void
+    public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
         $factory = new BrowserFactory();
         self::$browser = $factory->createBrowser();
     }
 
-    public static function tearDownAfterClass(): void
+    public static function tearDownAfterClass()
     {
         parent::tearDownAfterClass();
         self::$browser->close();

--- a/tests/Communication/ConnectionTest.php
+++ b/tests/Communication/ConnectionTest.php
@@ -31,7 +31,7 @@ class ConnectionTest extends TestCase
      */
     protected $mocSocket;
 
-    public function setUp(): void
+    public function setUp()
     {
         parent::setUp();
         $this->mocSocket = new MockSocket();

--- a/tests/Communication/SessionTest.php
+++ b/tests/Communication/SessionTest.php
@@ -29,7 +29,7 @@ class SessionTest extends TestCase
      */
     protected $mockSocket;
 
-    public function setUp(): void
+    public function setUp()
     {
         parent::setUp();
         $this->mockSocket = new MockSocket();

--- a/tests/CookieTest.php
+++ b/tests/CookieTest.php
@@ -28,14 +28,14 @@ class CookieTest extends HttpEnabledTestCase
      */
     public static $browser;
 
-    public function setUp(): void
+    public function setUp()
     {
         parent::setUp();
         $factory = new BrowserFactory();
         self::$browser = $factory->createBrowser();
     }
 
-    public function tearDown(): void
+    public function tearDown()
     {
         parent::tearDown();
         self::$browser->close();

--- a/tests/HttpEnabledTestCase.php
+++ b/tests/HttpEnabledTestCase.php
@@ -18,7 +18,7 @@ class HttpEnabledTestCase extends BaseTestCase
     /** @var Process */
     private static $process;
 
-    public static function setUpBeforeClass(): void
+    public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
 
@@ -39,7 +39,7 @@ class HttpEnabledTestCase extends BaseTestCase
         }
     }
 
-    public static function tearDownAfterClass(): void
+    public static function tearDownAfterClass()
     {
         parent::tearDownAfterClass();
 
@@ -51,7 +51,7 @@ class HttpEnabledTestCase extends BaseTestCase
         return 'localhost:8083';
     }
 
-    protected static function sitePath(string $file): string
+    protected static function sitePath($file)
     {
         return 'http://localhost:8083/' . $file;
     }

--- a/tests/KeyboardApiTest.php
+++ b/tests/KeyboardApiTest.php
@@ -25,14 +25,14 @@ class KeyboardApiTest extends BaseTestCase
      */
     public static $browser;
 
-    public static function setUpBeforeClass(): void
+    public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
         $factory = new BrowserFactory();
         self::$browser = $factory->createBrowser();
     }
 
-    public static function tearDownAfterClass(): void
+    public static function tearDownAfterClass()
     {
         parent::tearDownAfterClass();
         self::$browser->close();

--- a/tests/MouseApiTest.php
+++ b/tests/MouseApiTest.php
@@ -25,14 +25,14 @@ class MouseApiTest extends BaseTestCase
      */
     public static $browser;
 
-    public static function setUpBeforeClass(): void
+    public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
         $factory = new BrowserFactory();
         self::$browser = $factory->createBrowser();
     }
 
-    public static function tearDownAfterClass(): void
+    public static function tearDownAfterClass()
     {
         parent::tearDownAfterClass();
         self::$browser->close();


### PR DESCRIPTION
Do **not** merge into `0.10`. To use in Respondens, merge into `release`.

This is a continuous PR backporting upstreams latest version branch to php5.

To bring up-to-date with upstream changes:

- Manually change `public const` to `const`
- Manually change `function (...): Something;` in abstracts or interfaces to remove the return type
- Use https://github.com/ondrejbouda/php7backport for the base
- Use https://github.com/Respondens/quill-delta-parser/blob/backports-php5.6/PHP5_TRANSPILATION.md for some bracket extras